### PR TITLE
feat: добавлен вывод самых популярных фильмов по жанру и годам

### DIFF
--- a/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
@@ -12,6 +12,7 @@ import java.time.LocalDate;
 import java.time.Month;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/films")
@@ -67,9 +68,19 @@ public class FilmController {
         return filmService.deleteLike(id, userId);
     }
 
+    /**
+     * Эндпойнт /films/popular?count={limit}&genreId={genreId}&year={year} [GET]
+     * @param count - размер списка фильмов (если не указан, то count=10)
+     * @param genreId - идентификатор жанра
+     * @param year - год выпуска
+     * @return Возвращает список самых популярных фильмов указанного жанра за нужный год
+     */
     @GetMapping("popular")
-    public List<Film> getPopular(@RequestParam(defaultValue = "10") int count) {
-        return filmService.getPopular(count);
+    public List<Film> getPopular(
+            @RequestParam(value = "count", defaultValue = "10", required = false) int count,
+            @RequestParam(value = "genreId", required = false) Optional<Integer> genreId,
+            @RequestParam(value = "year", required = false) Optional<Integer> year) {
+        return filmService.getPopularFiltered(count, genreId, year);
     }
 
     private boolean isDateValid(Film film) {

--- a/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
@@ -4,10 +4,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import ru.yandex.practicum.filmorate.exception.NotFoundException;
 import ru.yandex.practicum.filmorate.model.Film;
+import ru.yandex.practicum.filmorate.model.Genre;
 import ru.yandex.practicum.filmorate.storage.filmstorage.FilmStorage;
 import ru.yandex.practicum.filmorate.storage.userstorage.UserStorage;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +34,36 @@ public class FilmService {
 
     public List<Film> getPopular(int count) {
         return filmStorage.getTop(count);
+    }
+
+    /**
+     * Возвращает список из первых count фильмов по количеству лайков. Если в параметрах
+     * передано значение идентификатора жанра, список отфильтровывается, и в итоговом списке
+     * остаются только фильмы, имеющие в списке жанров пункт, который соответствует переданному идентификатору.
+     * Если в параметрах передается год, то список отфильтровывается таким образом, что в итоговом списке
+     * остаются только фильмы, имеющие год выпуска, который соответствует переданному параметру.
+     * @param count - размер списка фильмов
+     * @param genreId - идентификатор жанра
+     * @param year - год выпуска
+     * @return список List<Film> топ фильмов по количеству лайков, отфильтрованный по жанру и по году
+     */
+    public List<Film> getPopularFiltered(int count, Optional<Integer> genreId, Optional<Integer> year){
+        List<Film> filmList = filmStorage.getTop(count);
+        if (genreId.isPresent()){
+            filmList=filmList.stream()
+                    .filter(film -> film.getGenres()!=null)
+                    .filter(film -> film.getGenres().stream()
+                            .map(Genre::getId)
+                            .collect(Collectors.toList())
+                            .contains(genreId.get()))
+                    .collect(Collectors.toList());
+        }
+        if (year.isPresent()){
+            filmList=filmList.stream()
+                    .filter(film -> film.getReleaseDate().getYear()==year.get())
+                    .collect(Collectors.toList());
+        }
+        return filmList;
     }
 
     public List<Film> getAll() {


### PR DESCRIPTION
В коде изменил эндпойнт /films/popular (прежнее поведение сохраняется плюс добавлены возможные параметры genreId и year). Добавил метод  List<Film> getPopularFiltered в сервис. Теперь метод List<Film> getPopular не используется, но его удалять не стал на тот случай, если у кого-то в коде он будет использоваться. При рефакторинге, я думаю, их можно будет слить в один