### PR TITLE
fix: Переписать на лямбды

### DIFF
--- a/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
@@ -119,9 +119,8 @@ public class FilmService {
      * @author Vladimir Arlhipenko
      */
     public List<Film> getDirectorFilms(long directorId, String sortBy) {
-        if (directorStorage.findById(directorId).isEmpty()) {
-            throw new NotFoundException("Director with id=" + directorId + " not found");
-        }
+        directorStorage.findById(directorId)
+                .orElseThrow(() -> new NotFoundException("Director with id=" + directorId + " not found"));
         return filmStorage.getDirectorFilms(directorId, sortBy);
     }
 
@@ -135,8 +134,7 @@ public class FilmService {
     }
 
     private Film validateAndGetFilm(long filmId, long userId) {
-        userStorage.findById(userId)
-                .orElseThrow(() -> new NotFoundException("User with id=" + userId + " not found"));
+        validateUserId(userId);
 
         return filmStorage.findById(filmId)
                 .orElseThrow(() -> new NotFoundException("Film with id=" + filmId + " not found"));

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/directorstorage/DirectorDbStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/directorstorage/DirectorDbStorage.java
@@ -56,9 +56,8 @@ public class DirectorDbStorage implements DirectorStorage {
 
     @Override
     public Director update(Director director) {
-        if (findById(director.getId()).isEmpty()) {
-            throw new NotFoundException("Director with id=" + director.getId() + " not found");
-        }
+        findById(director.getId())
+                .orElseThrow(() -> new NotFoundException("Director with id=" + director.getId() + " not found"));
         String sql = "update directors set " +
                 "name=?" +
                 "where id=?";

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/filmstorage/FilmDbStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/filmstorage/FilmDbStorage.java
@@ -58,9 +58,8 @@ public class FilmDbStorage implements FilmStorage {
 
     @Override
     public Film update(Film film) {
-        if (findById(film.getId()).isEmpty()) {
-            throw new NotFoundException("Film with id=" + film.getId() + " not found");
-        }
+        findById(film.getId())
+                .orElseThrow(() -> new NotFoundException("Film with id=" + film.getId() + " not found"));
         String sql = "update film set " +
                 "name=?," +
                 "description=?," +

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/reviewstorage/ReviewDbStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/reviewstorage/ReviewDbStorage.java
@@ -124,8 +124,6 @@ public class ReviewDbStorage implements ReviewStorage {
     }
 
     private void validateId(long id) {
-        if (findById(id).isEmpty()) {
-            throw new NotFoundException("Review with id=" + id + " does not exist");
-        }
+        findById(id).orElseThrow(() -> new NotFoundException("Review with id=" + id + " does not exist"));
     }
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/userstorage/UserDbStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/userstorage/UserDbStorage.java
@@ -53,9 +53,8 @@ public class UserDbStorage implements UserStorage {
 
     @Override
     public User update(User user) {
-        if (findById(user.getId()).isEmpty()) {
-            throw new NotFoundException("User with id=" + user.getId() + " not exist");
-        }
+        findById(user.getId())
+                .orElseThrow(() -> new NotFoundException("User with id=" + user.getId() + " not exist"));
         String sql = "update users set " +
                 "email=?," +
                 "login=?," +


### PR DESCRIPTION
Исправлены замечания ревьюера:
https://github.com/sergey-oreshkin/java-filmorate/pull/25#discussion_r912908438
https://github.com/sergey-oreshkin/java-filmorate/pull/25#discussion_r912927969

и аналогичные места в классах DirectorDbStorage и UserDbStorage. 
Также в методе validateAndGetFilm убрал дублирование кода (строку в лямбдой заменил на вызов метода с аналогичной логикой)